### PR TITLE
Avoid highlight being escaped

### DIFF
--- a/app/src/devtools/panel/js/handlers.js
+++ b/app/src/devtools/panel/js/handlers.js
@@ -23,7 +23,7 @@ function handleShowData() {
     <span class="close">&times;</span>
     <h3 class="mgb-30">Data passed into the sink</h3>
     <div style="text-align:left">
-        <p>${filterData ? cleanData(colorData(data, filterData)) : cleanData(data)}</p>
+        <p>${filterData ? colorData(cleanData(data), filterData) : cleanData(data)}</p>
     </div>`);
     $("#modal").css("display", "block");
 }


### PR DESCRIPTION
Before, the data that was supposed to be highlighted was not because it was escape :

![Old](https://github.com/kevin-mizu/domloggerpp/assets/52674895/6557b9c9-014b-437c-92b0-a3d60114ff7c)

https://github.com/kevin-mizu/domloggerpp/blob/3fcf68b18c605778fe1248bac6fefeefee112ccc/app/src/devtools/panel/js/handlers.js#L26

I've changed the order of the functions so that the data can be properly highlighted.

![New](https://github.com/kevin-mizu/domloggerpp/assets/52674895/8eb27163-daff-46a0-833b-8d303717c8d6)
