### PR TITLE
Avoid calling toString when checking the type of the logged object

### DIFF
--- a/app/scripts/src/utils/utils.js
+++ b/app/scripts/src/utils/utils.js
@@ -134,8 +134,10 @@ const isThisInteresting = (parentObject, thisArg) => {
     if (!thisArg)
         return false;
 
+    const type = parentObject[Symbol.toStringTag]
+    
     // Avoit thisArg logging in case of window || document methods (ie: window.postMessage)
-    if (`${parentObject}` === "[object Window]" || `${parentObject}` === "[object HTMLDocument]")
+    if (type === "Window" || type === "HTMLDocument")
         return false;
 
     return true;


### PR DESCRIPTION
The extension was throwing Illegal Invocation errors when I hooked `URLSearchParams.prototype.get`, because of the logged object's toString function being called in this funcion.

To fix this, I modified the function to use the logged object's toStringTag to check its type instead of calling its toString function.