### PR TITLE
Create issue templates for Bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Please complete the following information:**
+ - OS:
+ - Browser and version:
+ - Extension version:
+
+**Describe the bug**
+A clear and concise description of what the bug is. Do not hesitate to add screenshots.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error


### PR DESCRIPTION
Provides a template for contributors when creating an issue for a bug report.

![image](https://github.com/user-attachments/assets/512bcfc4-fcb2-4300-9801-939750754073)
