### PR TITLE
Add tooltips on SVG icons inside Popup & Devtools tab

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,1 +1,1 @@
-manifest-firefox.json
+manifest-chrome.json

--- a/app/src/devtools/panel/js/main.js
+++ b/app/src/devtools/panel/js/main.js
@@ -173,8 +173,8 @@ const initTable = () => {
     // Buttons
     $("#import").on("click",handleImportClick);
     $("#importFile").on("change", handleImport);
-    $("#remove").on("click",handleClear);
-    $("#export").on("click",handleExport);
+    $("#remove").on("click", handleClear);
+    $("#export").on("click", handleExport);
     $("#settings").on("click", handleSettingsNavigation);
 }
 

--- a/app/src/devtools/panel/panel.html
+++ b/app/src/devtools/panel/panel.html
@@ -20,6 +20,7 @@
 
     <div id="fullscreen" data-fullscreen="off" title="Fullscreen ON/OFF" class="fullscreen-button">
         <svg width="24px" viewBox="0 0 512 512" class="pointer text-color mgl-10 mgr-10">
+            <title>Enable/Disable Fullscreen</title>
             <use id="fullscreen-svg" xlink:href="./img/angle-down.svg#angle-icon"></use>
         </svg>
     </div>
@@ -73,19 +74,24 @@
         <div class="mgb-10">
             <a class="no-deco" href="https://github.com/kevin-mizu/domloggerpp">
                 <svg width="19px" viewBox="0 0 512 512" class="pointer text-color mgl-10 mgr-10">
+                    <title>Github Repository</title>
                     <use xlink:href="./img/github-solid.svg#github-icon"></use>
                 </svg>
             </a>
             <svg id="import" width="19px" viewBox="0 0 512 512" class="pointer text-color mgl-10 mgr-10">
+                <title>Import Results</title>
                 <use xlink:href="./img/file-import-solid.svg#file-import-icon"></use>
             </svg>
             <svg id="remove" width="19px" viewBox="0 0 512 512" class="pointer text-color mgl-10 mgr-10">
+                <title>Clear History</title>
                 <use xlink:href="./img/trash-solid.svg#trash-icon"></use>
             </svg>
             <svg id="export" width="19px" viewBox="0 0 512 512" class="pointer text-color mgl-10 mgr-10">
+                <title>Export Results</title>
                 <use xlink:href="./img/file-export-solid.svg#file-export-icon"></use>
             </svg>
             <svg id="settings" width="19px" viewBox="0 0 512 512" class="pointer text-color mgl-10 mgr-10">
+                <title>Extension Settings</title>
                 <use xlink:href="./img/gear-solid.svg#gear-icon"></use>
             </svg>
             <input type="file" id="importFile" hidden>

--- a/app/src/popup/popup.html
+++ b/app/src/popup/popup.html
@@ -53,13 +53,16 @@
         <div class="mgt-10 mgb-10">
             <a href="https://github.com/kevin-mizu/domloggerpp">
                 <svg width="19px" viewBox="0 0 512 512" class="pointer text-color mgr-10">
+                    <title>Github Repository</title>
                     <use xlink:href="./img/github-solid.svg#github-icon"></use>
                 </svg>
             </a>
             <svg id="remove" width="17px" viewBox="0 0 512 512" class="pointer text-color mgr-10">
+                <title>Clear History</title>
                 <use xlink:href="./img/trash-solid.svg#trash-icon"></use>
             </svg>
             <svg id="settings" width="19px" viewBox="0 0 512 512" class="pointer text-color mgr-10">
+                <title>Extension Settings</title>
                 <use xlink:href="./img/gear-solid.svg#gear-icon"></use>
             </svg>
         </div>


### PR DESCRIPTION
# Feature

Add tooltips on SVG icons inside Popups and DevTools tab when the mouse hovers over an icon for a short amount of time.

## DevTools tab

<img width="560" alt="image" src="https://github.com/user-attachments/assets/48760a86-32ce-411a-ae24-bb3fb09b7637">

## Popup

<img width="485" alt="image" src="https://github.com/user-attachments/assets/1954a9cd-eec1-4b82-a34a-def65cbfc513">
