### PR TITLE
Fix: Avoid using this in template of App.vue [workshop]

### DIFF
--- a/workshops/grehack2024/app/src/App.vue
+++ b/workshops/grehack2024/app/src/App.vue
@@ -57,7 +57,7 @@
         </button>
         <a
           v-if="selectedChallenge.solution"
-          :href="selectedChallenge.sameOrigin ? `${this.$el.ownerDocument.location.origin}${selectedChallenge.solution}` : selectedChallenge.solution"
+          :href="selectedChallenge.sameOrigin ? `${$el.ownerDocument.location.origin}${selectedChallenge.solution}` : selectedChallenge.solution"
           :target="selectedChallenge.solutionTarget || '_blank'"
         >
           <button class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 mx-2">Solution</button>


### PR DESCRIPTION
This fix resolves the crash on challenge 16, the reference to `$el` is accessed via `this` in the template part which causes the problem with the code built for production.

<img width="715" alt="crash console" src="https://github.com/user-attachments/assets/39c5dfba-728a-456f-a4ac-291701da23c3">
